### PR TITLE
Feature/#25 검색 관련 버그픽스

### DIFF
--- a/scripts/index.js
+++ b/scripts/index.js
@@ -53,7 +53,7 @@ $searchMovieInput.addEventListener("focusout", (e) => {
 const handleSearchMovieWithDebounce = debounce((e) => {
   window.currentPageNumber = 0;
   const moveList = getSearchedMovieList(e.target.value);
-  render(moveList);
+  renderMovieList(moveList);
 });
 $searchMovieInput.addEventListener("keyup", handleSearchMovieWithDebounce);
 

--- a/scripts/tabViewController.js
+++ b/scripts/tabViewController.js
@@ -55,10 +55,8 @@ export async function getMovieListOfHome() {
 }
 
 export async function getSearchedMovieListOfHome(keyword) {
-  if (keyword === "") {
-    getMovieListOfHome();
-    return;
-  }
+  if (keyword === "") return getMovieListOfHome();
+
   const response = await loadSearchedMovieListFromTMDB(
     keyword,
     window.currentPageNumber + 1


### PR DESCRIPTION
## 💡 관련이슈
- close #25 

## 🍀 작업 요약
- 검색에서 오류가 뜬 이유는 아래 2가지 때문이었습니다.
  - 검색 keyup 핸들러에서 영화 목록을 불러오는 함수명에 오타 (render -> renderMovieList)
  - 검색한 영화 목록을 돌려주는 함수에서 keyword가 빈 문자열일 때, 반환값이 없었음
    (인기 영화 목록을 반환하도록 수정)

## 💬 리뷰 요구 사항
- 리뷰 예상 시간 :  `1분`

## 💛 미리보기
디자인 수정이 없습니다!
